### PR TITLE
fix:BJTUParser重叠课程丢失问题等，简化教室名称显示

### DIFF
--- a/src/main/java/parser/BJTUParser.kt
+++ b/src/main/java/parser/BJTUParser.kt
@@ -12,114 +12,79 @@ var debug = false
 
 class BJTUParser(source: String) : Parser(source) {
     override fun generateCourseList(): List<Course> {
-
         //使用jsoup解析源码
         val doc = org.jsoup.Jsoup.parse(source)
-
         //获取课程表的table
         val table = doc.getElementsByClass("table table-bordered")
         //因为byclass拿到的是一个数组所以[0],获取列trs
         val trs = table[0].getElementsByTag("tr")
-
-        //用的set，存课程信息
-        val setOfClasses = hashSetOf<Course>()
+        val result = arrayListOf<Course>()
         var weekdayNo: Int//代表星期几
         var isFirstLine: Boolean//因为第一个显示的是课程时间段，得筛掉
-
         for ((timeNo, tr) in trs.withIndex()) {
             val tds = tr.getElementsByTag("td")
             isFirstLine = true
             weekdayNo = 1
             for (td in tds) {
-                //比方说获取周一第一节的所有课 的文本信息
                 val courseSource = td.text().trim()
-                var numOfClass: Int
-                var courseSources: List<String> = ArrayList()
-                if (courseSource == "") {
-
-                    numOfClass = 0
-                } else {
-                    val regex = Regex("\\w\\w\\w\\w\\w\\w\\w")
-                    courseSources = regex.split(courseSource)
-
-                    numOfClass = courseSources.size - 1
-                }
-
-
-                if(debug)
-                    println("$courseSource  $numOfClass")
-
-                if (isFirstLine) {
-                    isFirstLine = false
-                    continue
-                }
-
-
-                var startWeek = 1
-                var endWeek = 16
-                var type = 0
-                var className = ""
-                var classRoom = ""
-                var classTeacher = ""
-                for (each in courseSources) {
-                    if (each == "")
+                if (debug)
+                    println(courseSource)
+                if (courseSource != "") {
+                    if (isFirstLine) {
+                        isFirstLine = false
                         continue
+                    }
+                    val regex = Regex("\\w{7}\\s\\S+\\s[^\\[]+\\[\\W\\]\\s[^A-Z]+\\w{5}")
+                    val courseLine = regex.findAll(courseSource).toList()
+                    for (each in courseLine) {
 
-                    val regexClassName = Regex("]\\s.+\\s\\[")
-                    className = regexClassName.find(each)?.value?.split(" ")?.get(1).toString()
+                        val tempEach = each.value
+                        var startWeek: Int
+                        var endWeek: Int
+                        var className: String
+                        var classRoom: String
+                        var classTeacher: String
 
-                    val regexClassRoom = Regex("\\S+\\s\\w\\w\\d\\d\\d")
-                    classRoom = regexClassRoom.find(each)?.value?.split(" ")?.get(0).toString() + regexClassRoom.find(
-                        each
-                    )?.value?.split(" ")?.get(1).toString()
+                        val regexClassName = Regex("]\\s.+\\s\\[")
+                        className = regexClassName.find(tempEach)?.value.toString()
+                        className = className.slice(2..className.length - 3)
+                        val regexClassRoom = Regex("[A-Z]{2}\\d\\d\\d")
+                        classRoom =regexClassRoom.find(tempEach)?.value.toString()
+                        val regexClassTeacher = Regex("\\d\\d周\\s\\S+")
+                        classTeacher = regexClassTeacher.find(tempEach)?.value?.split(" ")?.get(1).toString()
+                        val regexStartWeek = Regex("]\\s第\\d\\d")
+                        startWeek = regexStartWeek.find(tempEach)?.value?.slice(3..4)?.toInt() ?: 1
+                        val regexEndWeek = Regex("\\d\\d周")
+                        endWeek = regexEndWeek.find(tempEach)?.value?.slice(0..1)?.toInt() ?: 16
+                        var type: Int = if (tempEach.contains(",")) {
+                            if (endWeek % 2 == 0) 2 else 1
+                        } else {
+                            0
+                        }
+                        if (className != "")
+                            result.add(
+                                Course(
+                                    name = className,
+                                    day = weekdayNo,
+                                    room = classRoom,
+                                    teacher = classTeacher,
+                                    startNode = timeNo,
+                                    endNode = timeNo,
+                                    type = type,
+                                    startWeek = startWeek,
+                                    endWeek = endWeek
+                                )
+                            )
 
-                    val regexClassTeacher = Regex("\\d\\d周\\s\\S+")
-                    classTeacher = regexClassTeacher.find(each)?.value?.split(" ")?.get(1).toString()
-
-                    val regexStartWeek = Regex("]\\s第\\d\\d")
-                    startWeek = regexStartWeek.find(each)?.value?.slice(3..4)?.toInt() ?: 1
-
-                    val regexEndWeek = Regex("\\d\\d周")
-                    endWeek = regexEndWeek.find(each)?.value?.slice(0..1)?.toInt() ?: 16
-
-                    if (each.contains(",")){
-                        type = if (endWeek%2==0) 2 else 1
-                    }else{
-                        type = 0
                     }
 
                 }
-
-                if (className!="")
-                    setOfClasses.add(
-                        Course(
-                            name = className,
-                            day = weekdayNo,
-                            room = classRoom,
-                            teacher = classTeacher,
-                            startNode = timeNo,
-                            endNode = timeNo,
-                            type = type,
-                            startWeek = startWeek,
-                            endWeek = endWeek
-                        )
-                    )
-
                 weekdayNo++
-
-
             }
         }
-
-
-        //整合进result里
-        val result = arrayListOf<Course>()
-        for (each in setOfClasses) {
-            result.add(each)
-
-            if(debug)
+        if (debug)
+            for (each in result)
                 println(each)
-        }
         return result
     }
 
@@ -128,9 +93,13 @@ class BJTUParser(source: String) : Parser(source) {
 fun main() {
 
 
-    val file = File("C:\\Users\\14223\\Desktop\\北京交通大学教学服务管理平台02.html")
-//    BJTUParser(file.readText()).generateCourseList()
+    val file = File("C:\\Users\\14223\\Desktop\\北京交通大学教学服务管理平台.html")
+    if (debug) {
+        BJTUParser(file.readText()).generateCourseList()
 
-    val parser = BJTUParser(file.readText())
-    parser.saveCourse()
+    } else {
+        val parser = BJTUParser(file.readText())
+        parser.saveCourse()
+    }
+
 }

--- a/src/main/java/test/BJTUTest.kt
+++ b/src/main/java/test/BJTUTest.kt
@@ -5,7 +5,7 @@ import java.io.File
 
 //北京交通大学本科
 fun main(){
-    val file = File("C:\\Users\\14223\\Desktop\\北京交通大学教学服务管理平台.html")
+    val file = File("C:\\Users\\14223\\Desktop\\北京交通大学教学服务管理平台01.html")
     val parser = BJTUParser(file.readText())
     parser.saveCourse()
 }


### PR DESCRIPTION
emmmm手机端上导入的时候有的课程名显示null
另外北京交通大学的教务网址用mis.bjtu.edu.cn好一些（旧的那个有时候会连不上
( •̀ ω •́ )y