### PR TITLE
[add]上海工程技术大学教学管理信息系统

### DIFF
--- a/src/main/java/parser/SUESParser.kt
+++ b/src/main/java/parser/SUESParser.kt
@@ -1,0 +1,341 @@
+package main.java.parser
+
+import bean.Course
+import main.java.bean.TimeDetail
+import main.java.bean.TimeTable
+import org.jsoup.Jsoup
+import parser.Parser
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.collections.ArrayList
+
+class SUESParser(source: String) : Parser(source) {
+
+    //document.getElementById("main").contentWindow.document.getElementById("contentListFrame").contentWindow
+    private val dom = Jsoup.parse(source)
+
+    //“按照时间顺序处理课程”
+    var followTimeOrder = false
+
+    //类似“小爱课程表”的自定义课程数据类
+    data class MyCourse(
+        var name: String,
+        var position: String,
+        var teacher: String,
+        var weeks: ArrayList<Int>,
+        var day: Int,
+        var sections: ArrayList<Int>,
+        //当然，小爱没有下面这几个字段
+        var note: String = "",
+        var credit: Float = 0f,
+        var startTime: String = "",
+        var endTime: String = ""
+    )
+
+    private val courseInfos = arrayListOf<MyCourse>()
+
+    //将自定义课程类转换成需要的课程类
+    private fun myCourse2Course(courseInfos: ArrayList<MyCourse>): ArrayList<Course> {
+        val res = arrayListOf<Course>()
+
+        courseInfos.forEach { e ->
+            //将非连续的节次分段
+            val sections = arrayListOf<List<Int>>()
+            val s = e.sections
+            if (s.isNotEmpty()) {
+                var temp = arrayListOf(s[0])
+                for (i in 1 until s.count()) {
+                    if (s[i - 1] + 1 != s[i]) {
+                        sections.add(temp)
+                        temp = arrayListOf(s[i])
+                    } else {
+                        temp.add(s[i])
+                    }
+                }
+                sections.add(temp)
+            }
+
+            //按分段后的连续节次分别创建Course对象导入
+            sections.forEach {
+                Common.weekIntList2WeekBeanList(e.weeks).forEach { week ->
+                    res.add(
+                        Course(
+                            name = e.name,
+                            teacher = e.teacher,
+                            room = e.position,
+                            startNode = it.first(),
+                            endNode = it.last(),
+                            startWeek = week.start,
+                            endWeek = week.end,
+                            type = week.type,
+                            day = e.day + 1,
+                            note = e.note,
+                            credit = e.credit,
+                            startTime = e.startTime,
+                            endTime = e.endTime
+                        )
+                    )
+                }
+            }
+        }
+        return res
+    }
+
+    //转换课程节次
+    //“按时间顺序”时将9,10,11,12,13,14节调整为11,12,13,14,9,10
+    private fun getSection(s: Int): Int {
+        if (followTimeOrder) {
+            if (s < 8) {
+                return s + 1
+            } else if (s < 12) {
+                return s + 3
+            } else if (s < 14) {
+                return s - 3
+            }
+        }
+        return s + 1
+    }
+
+    private var termFrom = 0
+    private var termStart = 0
+    private var termEnd = 0
+    private var termLength = 0
+
+    //获取学期总周数，顺便保存处理validWeeks字符串所需的参数
+    override fun getMaxWeek(): Int? {
+        val termInfo = Regex("""table0\.marshalTable\((.+?),(.+?),(.+?)\);""").find(source)
+        return if (termInfo != null) {
+            termFrom = termInfo.groupValues[1].toInt() //validWeeks字符串的起始位置
+            termStart = termInfo.groupValues[2].toInt() //开始周（第一周）
+            termEnd = termInfo.groupValues[3].toInt() //结束周
+            termLength = termEnd - termStart + 1
+            termLength
+        } else null
+    }
+
+    //处理validWeeks字符串，返回weekIntList
+    private fun getWeeks(validWeeks: String): ArrayList<Int> {
+        val week = arrayListOf<Int>()
+        val str = validWeeks.repeat(2)
+        for (i in termStart..termEnd) {
+            if (str[termFrom + i - 2] == '1') {
+                week.add(i)
+            }
+        }
+        return week
+    }
+
+    //获取课程表名称，这里用日期命名
+    override fun getTableName(): String = "${LocalDate.now()}导入的课表"
+
+    //获取节点（时间表一天的课程节数？）
+    //generateTimeTable().timeList.count()
+    override fun getNodes(): Int = 14
+
+    //获取起始日期
+    //找到最早开始的课程。通过其“第一次上课时间”推断开学日期
+    //理论上任意课程都能推出来，后面研究一下
+    override fun getStartDate(): String {
+        //英文浏览器环境会显示Sep 6, 2022
+        //中文浏览器环境会显示2022-9-6
+        val cnFormatter = DateTimeFormatter.ofPattern("yyyy-M-d")
+        val enFormatter = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale("en"))
+
+        var firstCourseName = ""
+        var firstCourseDate = LocalDate.of(1970, 1, 1)
+        fun getDate(str: String): LocalDate? {
+            return if (str.count { it == '-' } == 2) {
+                LocalDate.parse(str, cnFormatter)
+            } else if (str.count { it == ',' } == 1) {
+                LocalDate.parse(str, enFormatter)
+            } else {
+                null
+            }
+        }
+
+        dom.select(".listTable")[1].select("tr").drop(1).forEach {
+            val cells = it.select("td").map { i -> i.text() }
+            val listCourseID = cells[5]
+            val listCourseName = cells[3] + if (listCourseID.isNotBlank()) "($listCourseID)" else ""
+            val listFirstDate = getDate(cells[8])
+            if (listFirstDate != null) {
+                if (firstCourseDate == LocalDate.of(1970, 1, 1) ||
+                    firstCourseDate > listFirstDate
+                ) {
+                    firstCourseName = listCourseName
+                    firstCourseDate = listFirstDate
+                }
+            }
+        }
+
+        var firstDay = 8
+        var firstWeek = termLength + 1
+        courseInfos.forEach {
+            if (it.name == firstCourseName) {
+                if (it.weeks[0] < firstWeek) {
+                    firstWeek = it.weeks[0]
+                    firstDay = it.day
+                } else if (it.weeks[0] == firstWeek && it.day < firstDay) {
+                    firstDay = it.day
+                }
+            }
+        }
+
+        if (firstDay < 8 && firstWeek <= termLength) {
+            firstCourseDate.minusDays(((firstWeek - 1) * 7 + firstDay - 1).toLong())
+            firstCourseDate.minusDays((firstCourseDate.dayOfWeek.value - 2).toLong())
+        }
+        if (firstCourseDate == LocalDate.of(1970, 1, 1)) {
+            return "2021-9-6" //找不到就摆烂了，返回Generator原来包含的日期
+        }
+        return cnFormatter.format(firstCourseDate)
+    }
+
+    //生成时间表
+    //被我写死了，时间安排应该一时半会儿不会有什么大变动
+    override fun generateTimeTable(): TimeTable {
+        //by stevenlele
+        /*
+        val timeList = arrayListOf<TimeDetail>()
+        dom.select(".listTable")[0].select("tr")[1].select("td").drop(1).forEachIndexed { i, td ->
+            val text = td.text()
+            val time = Regex("""\((.*?)~(.*?)\)""").find(text)
+            if (time != null) {
+                timeList.add(
+                    TimeDetail(
+                        node = i + 1,
+                        startTime = time.groupValues[1],
+                        endTime = time.groupValues[2]
+                    )
+                )
+            }
+        }
+        */
+
+        //上课顺序:1,2,3,4,5,6,7,8,13,14,9,10,11,12。在课表界面显示如此，13、14就在最后。
+        val timeList: List<TimeDetail>
+        if (followTimeOrder) {
+            timeList = listOf(
+                TimeDetail(node = 1, startTime = "08:15", endTime = "09:00"),
+                TimeDetail(node = 2, startTime = "09:00", endTime = "09:45"),
+                TimeDetail(node = 3, startTime = "10:05", endTime = "10:50"),
+                TimeDetail(node = 4, startTime = "10:50", endTime = "11:35"),
+                TimeDetail(node = 5, startTime = "13:00", endTime = "13:45"),
+                TimeDetail(node = 6, startTime = "13:45", endTime = "14:30"),
+                TimeDetail(node = 7, startTime = "14:50", endTime = "15:35"),
+                TimeDetail(node = 8, startTime = "15:35", endTime = "16:20"),
+                TimeDetail(node = 9, startTime = "16:30", endTime = "17:15"),
+                TimeDetail(node = 10, startTime = "17:15", endTime = "18:00"),
+                TimeDetail(node = 11, startTime = "18:00", endTime = "18:45"),
+                TimeDetail(node = 12, startTime = "18:45", endTime = "19:30"),
+                TimeDetail(node = 13, startTime = "19:30", endTime = "20:15"),
+                TimeDetail(node = 14, startTime = "20:15", endTime = "21:00")
+            )
+            return TimeTable(name = "调序时间表", timeList = timeList)
+        } else {
+            timeList = listOf(
+                TimeDetail(node = 1, startTime = "08:15", endTime = "09:00"),
+                TimeDetail(node = 2, startTime = "09:00", endTime = "09:45"),
+                TimeDetail(node = 3, startTime = "10:05", endTime = "10:50"),
+                TimeDetail(node = 4, startTime = "10:50", endTime = "11:35"),
+                TimeDetail(node = 5, startTime = "13:00", endTime = "13:45"),
+                TimeDetail(node = 6, startTime = "13:45", endTime = "14:30"),
+                TimeDetail(node = 7, startTime = "14:50", endTime = "15:35"),
+                TimeDetail(node = 8, startTime = "15:35", endTime = "16:20"),
+                TimeDetail(node = 9, startTime = "18:00", endTime = "18:45"),
+                TimeDetail(node = 10, startTime = "18:45", endTime = "19:30"),
+                TimeDetail(node = 11, startTime = "19:30", endTime = "20:15"),
+                TimeDetail(node = 12, startTime = "20:15", endTime = "21:00"),
+                TimeDetail(node = 13, startTime = "16:30", endTime = "17:15"),
+                TimeDetail(node = 14, startTime = "17:15", endTime = "18:00")
+            )
+            return TimeTable(name = "原始时间表", timeList = timeList)
+        }
+    }
+
+    //生成课程列表
+    override fun generateCourseList(): List<Course> {
+        //把原来存在对象里的信息清空
+        //否则像ECUPLTest那样先generateCourseList
+        //再在saveCourse里generate一次课表就乱了
+        courseInfos.clear()
+        getMaxWeek()
+        Regex("activity = new TaskActivity").split(source).forEach { i ->
+            //教师编号、教师姓名、课程编号、课程名称、教室编号、教室名称、validWeeks字符串
+            val courseData = Regex("""\("(.*?)","(.*?)","(.*?)","(.*?)","(.*?)","(.*?)","(.*?)"\);""").find(i)
+
+            if (courseData != null) {
+                val courseName = courseData.groupValues[4]
+                val position = courseData.groupValues[6]
+                val teacher = courseData.groupValues[2]
+                val weeks = getWeeks(courseData.groupValues[7])
+                val sectionData = Regex("""index =(.*?)\*unitCount\+(.*?);""").findAll(i)
+                val day = sectionData.first().groupValues[1].toInt()
+                val sectionDays = arrayListOf<Int>()
+
+                sectionData.forEach {
+                    sectionDays.add(getSection(it.groupValues[2].toInt()))
+                }
+                sectionDays.sort()
+
+                //从课程列表单元格里找备注和学分
+                val courseList = dom.select(".listTable")[1]
+                var note = ""
+                var credit = 0f
+                courseList.select("tr").drop(1).forEach {
+                    val cells = it.select("td")
+                    val listCourseID = cells[5].text()
+                    val listCourseName = cells[3].text() + if (listCourseID.isNotBlank()) "($listCourseID)" else ""
+                    val listCredit = cells[4].text().toFloat()
+                    val listNote = cells[7].text()
+                    if (courseName == listCourseName) {
+                        note = listNote
+                        credit = listCredit
+                    }
+                }
+
+                //D、E、F楼的第3、4节课10:25开始，11:55下课
+                //但似乎该项目的生成流程会忽略startTime与endTime参数
+                var startTime = ""
+                var endTime = ""
+                if (Regex("""[DEF][0-9]{3}多""").matches(position) &&
+                    sectionDays.first() == 3 &&
+                    sectionDays.last() == 4
+                ) {
+                    startTime = "10:25"
+                    endTime = "11:55"
+                }
+
+                //合并当天相同课程，转换时再分段拆开
+                val same = courseInfos.firstOrNull {
+                    it.name == courseName &&
+                            it.position == position &&
+                            it.teacher == teacher &&
+                            it.day == day &&
+                            it.weeks == weeks
+                }
+                if (same == null) {
+                    courseInfos.add(
+                        MyCourse(
+                            courseName,
+                            position,
+                            teacher,
+                            weeks,
+                            day,
+                            sectionDays,
+                            note,
+                            credit,
+                            startTime,
+                            endTime
+                        )
+                    )
+                } else {
+                    same.sections.addAll(sectionDays)
+                    same.sections.sort()
+                }
+            }
+        }
+        return myCourse2Course(courseInfos)
+    }
+}

--- a/src/main/java/test/SUESTest.kt
+++ b/src/main/java/test/SUESTest.kt
@@ -1,0 +1,50 @@
+package main.java.test
+
+import main.java.parser.SUESParser
+import java.io.File
+
+fun main() {
+    val source = File("d:/j.html").readText()
+    SUESParser(source).apply {
+        //followTimeOrder=true
+
+        saveCourse()
+
+        val timeTable=generateTimeTable()
+        var timeTableText="["
+        timeTable.timeList.forEach{
+            timeTableText+="{"+
+                "\"endTime\":\"${it.endTime}\","+
+                "\"node\":${it.node},"+
+                "\"startTime\":\"${it.startTime}\","+
+                "\"timeTable\":1"+
+                "},"
+        }
+        timeTableText=timeTableText.removeSuffix(",")+"]"
+
+        //test.wakeup_schedule
+        println("replace first 3 lines with following output data:")
+        println("=============================")
+
+        //header
+        println("{\"courseLen\":45,\"id\":1,\"name\":\"${timeTable.name}\",\"sameBreakLen\":false,\"sameLen\":true,\"theBreakLen\":20}")
+
+        //timePreference
+        println(timeTableText)
+
+        //colorScheme
+        println("{\"background\":\"\",\"courseTextColor\":-1,\"id\":1,\"itemAlpha\":60," +
+                "\"itemHeight\":64,\"itemTextSize\":12,\"maxWeek\":${getMaxWeek()},\"nodes\":${getNodes()}," +
+                "\"showOtherWeekCourse\":true,\"showSat\":true,\"showSun\":true," +
+                "\"showTime\":false,\"startDate\":\"${getStartDate()}\",\"strokeColor\":-2130706433," +
+                "\"sundayFirst\":false,\"tableName\":\"${getTableName()}\",\"textColor\":-16777216," +
+                "\"timeTable\":1,\"type\":0,\"widgetCourseTextColor\":-1,\"widgetItemAlpha\":60," +
+                "\"widgetItemHeight\":64,\"widgetItemTextSize\":12,\"widgetStrokeColor\":-2130706433," +
+                "\"widgetTextColor\":-16777216}")
+
+        //courseList(baseList)
+        //courseDetailList(detailList)
+
+        println("=============================")
+    }
+}


### PR DESCRIPTION
我正在提交从“上海工程技术大学”的“教学管理信息系统”（[http://jxxt.sues.edu.cn](http://jxxt.sues.edu.cn)）导入课程表到“WakeUp课程表”App的适配代码。

我按照 `Parser` 类中函数的名称和他人贡献的代码猜测了一些函数的作用，并对其进行了重写，还请帮忙检查一下是否有哪里没理解对。

有一些在项目维护者大大处理这个拉取请求的时候可能遇到的一些问题：

> “stevenlele”已经在App内为“上海工程技术大学”提供了适配项目，我是否在重复适配？

我使用这个项目导入的课程表较为混乱，连续的课程被拆散成单节，部分课程还有重叠。我以及许多用户可能都难以阅读课程表中的信息。在使用由他贡献的 `ECUPLParser` 测试时，我也遇到了类似的问题。不过还是感谢 @stevenlele ，这里提交的部分代码参考了 `ECUPLParser`。

> WakeUp课程表为树维教务提供了多种导入方式，本仓库也提供了 `SupwisdomParser` 类。在使用他们的时候遇到了什么问题？

教务系统显示课程表时采用了嵌套iFrame框架，手机浏览器操作导入或在电脑浏览器保存网页似乎都不能获得框架内课程表页面的信息。 _如果在进行导入的时候，App或脚本能够寻找（甚至是嵌套的）iFrame并获取内部的信息，说不定树维教务的通用导入成功率还能提升呢。_

我将框架内的页面地址记下，先登录教务，再转到记下的地址，将框架内的页面作为了顶层页面打开。此时，无论是手机导入，还是电脑运行脚本，导入过程都挺顺利的。通用教务可以很好地识别课程节次、星期等信息。只是，识别课程周次的部分似乎出现了一些问题。在一个学期仅有十余周的情况下，课程表里出现了在第四十周开设的课程。

下方是 `SupwisdomParser` 类中处理 `validWeeks` 字符串的方式，以及我用JavaScript写的能获得预期结果的处理方式。分别使用一门1-16周以及另一门18-19周课程的 `validWeeks` 字符串对函数进行调用。

```kotlin
fun getWeeks(weekStr: String): ArrayList<Int> {
  //SupwisdomParser.kt:90
  val weekIntList = arrayListOf<Int>()
  weekStr.forEachIndexed { index, c ->
    if (c == '1') {
        weekIntList.add(index)
    }
  }
  return weekIntList
}

println(getWeeks("00000000000000000000000000000000000011111111111111110"))
//[36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]

println(getWeeks("11000000000000000000000000000000000000000000000000000"))
//[0, 1]
```

```javascript
//从包含课程信息的<script>标签内容中截取的一行
var data="table0.marshalTable(37,1,19);"
var termInfo = data.match(/table0.marshalTable\((.*?),(.*?),(.*?)\)/)
var term = {
  from: parseInt(termInfo[1]),
  start: parseInt(termInfo[2]),
  end: parseInt(termInfo[3]),
}

function getWeeks(vaildWeeks) {
  var week = []
  var str = vaildWeeks.repeat(2)
  for (i = term.start; i <= term.end; i++) {
    if (str.charAt(term.from + i - 2) == 1) {
      week.push(i)
    }
  }
  return week
}

console.log(getWeeks("00000000000000000000000000000000000011111111111111110"))
//[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]

console.log(getWeeks("11000000000000000000000000000000000000000000000000000"))
//[18, 19]
```

> 为何不修改 `SupwisdomParser` 类中相关部分（或从其继承并重写 `generateCourseList()`），而是完全推倒重来？

我并不敢贸然更改 `SupwisdomParser` 类中原始的内容，毕竟 `ECUPLParser` 和其他项目可能正在依赖他，更改其中的内容可能会影响他们工作。

还有一些学校教务奇怪的地方需要处理（具体在下面），理解并修改现有的代码也要不小的开销。我会一点JavaScript，不会Kotlin或Java。了解到WakeUp课程表提供这样一个仓库供用户参与适配，刚好之前用JS在“小爱课程表”中做了适配项目，便有了从那里生搬硬套过来的Kotlin代码。可能看着很奇怪，但这些玩意至少真的跑起来了。

这里还有一些我想问的问题，还请不吝赐教。

> 如何引用页面中的内容？

正如上方我使用通用导入时所说，获取课程表所在页面的HTML需要跨越几层iFrame。我可以在浏览器中正常导航到课表页面，然后找到 `#main` 框架中的 `#contentListFrame` 框架，这里面的网页才是最终的课程表页面。通用教务导入成功的页面与我在本地进行测试的页面都是这个。但与此同时，`#main` 框架页面内包含学期信息，将其作为课程表的名称是个不错的主意。只是我不知道WakeUp课程表传入的字符串会是怎样的，我又该如何分别引用这些框架内的信息。

> 如何布置可以与用户交互的控件？

在“小爱课程表”中，用户编写的脚本可以在浏览器环境使用 `window.alert()` 等函数或者小米提供的 `AIScheduleTools` 控件库弹出一些提示。我注意到一些WakeUp课程表导入项目有自定义界面，但我不知道具体应该如何实现。

我暂时没有打算自定义账号和密码的输入界面。除了我个人能力问题，还有一些其他的考虑。我了解WakeUp课程表在隐私政策中对用户的承诺，但因为有部分主体提供针对某所学校的查课公众号/小程序，他们正在通过重新包装的登录页面索要明文账号密码，并可能存在窃取敏感信息的行为。我并不希望WakeUp课程表（和我）（至少在这所学校）被卷入类似的讨论中。

学校的课程表挺奇怪的，13、14节课的上课时间在8、9节课之间。“小爱课程表”要求时间表必须按顺序安排，因此我只能将教务的13,14,9,10,11,12节课重新映射到小爱的9,10,11,12,13,14节课上。但WakeUp课程表完全可以把16:30上的第13节课放在21:00上的第12节课后面。我不清楚现在是否需要：

1. 依原样显示课程表（`followTimeOrder = false`，默认值）
2. 在代码内调整好课程顺序，再输出按时间排序的课程表（`followTimeOrder = true`）
3. 增加选项，让用户在1和2之间选择（如果可能提供和用户交互的控件，类似于 `followTimeOrder = window.confirm("可以将下午13、14节课按时间顺序插入到8、9节课之间，是否需要这么做？")`）

> 某些参数是否未在生成流程中被使用？

在这个项目的生成结果中，`[name].wakeup_schedule` 的前三行是固定的。虽然有获取时间表、课程名称等参数的函数可供重写，但在测试时他们似乎并未发挥作用。

另外，我希望导入不规则的课程时间信息。学校 _（为了他可怜的教学楼旁的食堂在中午下课时不会被挤爆，让DEF楼每天3-4节的课程晚20分钟上下课，这使得）_ 部分课程的时间安排与时间表错开，与WakeUp课程表的“自定义时间”功能不谋而合。目前的代码虽然在构造Course对象时允许传入时间信息，但是Parser生成的 `CourseDetailBean` 对象似乎并没有采用传入的信息，最终生成的 `[name].wakeup_schedule` 文件也自然没有包含这些信息。我不清楚这是否是预期的行为。

如果还有其他我需要做的事情，请尽管告诉我。

感谢。