### PR TITLE
[fix]SUESParser: 推断开学日期

### DIFF
--- a/src/main/java/parser/SUESParser.kt
+++ b/src/main/java/parser/SUESParser.kt
@@ -69,7 +69,7 @@ class SUESParser(source: String) : Parser(source) {
                             startWeek = week.start,
                             endWeek = week.end,
                             type = week.type,
-                            day = e.day + 1,
+                            day = e.day,
                             note = e.note,
                             credit = e.credit,
                             startTime = e.startTime,
@@ -182,14 +182,12 @@ class SUESParser(source: String) : Parser(source) {
             }
         }
 
-        if (firstDay < 8 && firstWeek <= termLength) {
-            firstCourseDate.minusDays(((firstWeek - 1) * 7 + firstDay - 1).toLong())
-            firstCourseDate.minusDays((firstCourseDate.dayOfWeek.value - 2).toLong())
+        if (firstDay < 8 && firstWeek <= termLength && firstCourseDate != LocalDate.of(1970, 1, 1)) {
+            firstCourseDate = firstCourseDate.minusDays(((firstWeek - 1) * 7 + firstDay - 1).toLong())
+            firstCourseDate = firstCourseDate.minusDays((firstCourseDate.dayOfWeek.value - 1).toLong())
+            return cnFormatter.format(firstCourseDate)
         }
-        if (firstCourseDate == LocalDate.of(1970, 1, 1)) {
-            return "2021-9-6" //找不到就摆烂了，返回Generator原来包含的日期
-        }
-        return cnFormatter.format(firstCourseDate)
+        return "2021-9-6" //找不到就摆烂了，返回Generator原来包含的日期
     }
 
     //生成时间表
@@ -271,7 +269,7 @@ class SUESParser(source: String) : Parser(source) {
                 val teacher = courseData.groupValues[2]
                 val weeks = getWeeks(courseData.groupValues[7])
                 val sectionData = Regex("""index =(.*?)\*unitCount\+(.*?);""").findAll(i)
-                val day = sectionData.first().groupValues[1].toInt()
+                val day = sectionData.first().groupValues[1].toInt() + 1
                 val sectionDays = arrayListOf<Int>()
 
                 sectionData.forEach {


### PR DESCRIPTION
这次拉取请求希望对 `SUESParser` 进行修改，主要为了“推断开学日期”功能可以 **“猜得准”** 。

修复了找到的“第一次上课时间”未经计算就返回的错误。_~死因：没注意到~ `LocalDate minusDays()` ~函数是返回对象的拷贝，忘记将其重新赋值给~ `firstCourseDate` ~变量。~_

修改了返回开学日期的逻辑，只有在页面下方课程列表中找到“第一次上课时间”最早的课程，并同时在课程表中找到对应课程第一节课的周次和星期时，才会用这些数据进行计算，并返回计算得到的第一周周一对应日期作为开学日期。

此外，现在从正则匹配结果中获得课程星期后，`day` 变量的值会立即在匹配结果的基础上加 `1`，保持在 `[1,7]` 的区间内。这与此项目参考的“小爱课程表”适配项目行为相同，也避免在计算开学日期或其他可能用到此数据的逻辑中误将 `[0,6]` 区间的星期数据当作 `[1,7]` 区间使用。

项目在已上线的客户端版本中使用时还遇到了其他的问题，还请关注一下[这条评论](https://github.com/YZune/CourseAdapter/pull/67#issuecomment-1264247695)（[https://github.com/YZune/CourseAdapter/pull/67#issuecomment-1264247695](https://github.com/YZune/CourseAdapter/pull/67#issuecomment-1264247695)）。谢谢。