### PR TITLE
[fix]SUESParser: 从中午分割课程

### DIFF
--- a/src/main/java/parser/SUESParser.kt
+++ b/src/main/java/parser/SUESParser.kt
@@ -46,7 +46,7 @@ class SUESParser(source: String) : Parser(source) {
             if (s.isNotEmpty()) {
                 var temp = arrayListOf(s[0])
                 for (i in 1 until s.count()) {
-                    if (s[i - 1] + 1 != s[i]) {
+                    if (s[i - 1] + 1 != s[i] || s[i-1] == 4) {
                         sections.add(temp)
                         temp = arrayListOf(s[i])
                     } else {


### PR DESCRIPTION
跨越午饭时间的超长课程应该从中午被切断，这样吃完午饭后在下午继续同一节课前还能收到来自WakeUp课程表的亲切问候。

晚饭时间就不需要考虑，~众所周知我校学生都会在晚上六点进行瞬移~晚上的时间表并没有留作休息的时间。