### PR TITLE
fix: 迁移到华中科技大学新教务系统

### DIFF
--- a/src/main/java/parser/HUSTParser.kt
+++ b/src/main/java/parser/HUSTParser.kt
@@ -5,54 +5,69 @@ import bean.Course
 import org.jsoup.Jsoup
 import parser.Parser
 import java.io.IOException
+
 /**
  * Created by [Xeu](https://github.com/ThankRain) at 2021/8/12 14:50
+ *
+ * Fixed by [GoForceX](https://github.com/GoForceX) at 2024/12/1 17:30
+ *
  * 华中科技大学微校园
- * @link http://hub.m.hust.edu.cn/kcb/index.jsp#kclist_section?kcname=&lsname=
+ * @link https://mhub.hust.edu.cn/kbPageController/by-course
  */
 class HUSTParser(source: String) : Parser(source = source) {
     override fun generateCourseList(): List<Course> {
         val doc = Jsoup.parse(source)
-        val list = doc.getElementById("ktlist")//Get Course List
-        val courses:MutableList<Course> = mutableListOf()
+        val list = doc.getElementsByClass("main-page-block").first() // Get Course List
+        val courses: MutableList<Course> = mutableListOf()
         list.children().toList().forEach { it ->
-            val courseName = it.getElementsByTag("Strong").first().text()
             val raws = it.getElementsByTag("p")
-            if (raws.size < 4){
+            if (raws.size < 3) {
                 throw IOException("课表格式有误:段落不足")
             }
-            val teacher = raws.first().text().run {
-                val start = "教师："
-                substring(indexOf(start) + start.length)
-            }
-            val population = raws[1].text()//人数
-            val courseObject = raws[2].text()//开课对象
-            val timeArranges = it.getElementsByClass("demo-grid")
-            timeArranges.forEach { timeArrange->
-            timeArrange.children().run {
-                val weeks = get(0).text()//周次
-                val day = get(1).text()//星期
-                val times = get(2).text()//节次
-                val place = get(3).text()//地点
-                if (!weeks.contains("周次")&&!day.contains("待定")){ //第一个为表头，忽略
-                    val startWeek = weeks.run { substring(0,indexOf("-")) }.toInt()
-                    val endWeek = weeks.run { substring(indexOf("-")+1) }.toInt()
-                    val startNode = times.run { substring(1,indexOf("-")) }.toInt()
-                    val endNode = times.run { substring(indexOf("-")+1,indexOf("节")) }.toInt()
-                    courses.add(Course(
-                        name = courseName,
-                        day = getDayInt(day),
-                        room = place,
-                        teacher = teacher,
-                        startNode = startNode,
-                        endNode = endNode,
-                        startWeek = startWeek,
-                        endWeek = endWeek,
-                        type = 0,
-                        note = "$population\n$courseObject"
-                    ))
+            val courseName = raws[0].text()
+
+            val courseObject = raws[2].text()// 开课对象
+            val timeArranges = it.getElementsByClass("search-details-body")
+            timeArranges.forEach { timeArrange ->
+                timeArrange.children().forEach { it ->
+                    val texts = it.getElementsByClass("text-box")
+                    val time = texts[0].text().run {
+                        val start = "时间:"
+                        substring(indexOf(start) + start.length).split(" ")
+                    }
+                    val weeks = time[0]// 周次
+                    val day = time[1]// 星期
+                    val times = time[2]// 节次
+
+                    val teacher = texts[1].text().run {
+                        val start = "教师:"
+                        substring(indexOf(start) + start.length)
+                    }
+
+                    val place = texts[2].text().run {
+                        val start = "教室:"
+                        substring(indexOf(start) + start.length)
+                    }
+
+                    val startWeek = weeks.run { substring(0, indexOf("-")) }.toInt()
+                    val endWeek = weeks.run { substring(indexOf("-") + 1, indexOf("周")) }.toInt()
+                    val startNode = times.run { substring(0, indexOf("-")) }.toInt()
+                    val endNode = times.run { substring(indexOf("-") + 1, indexOf("节")) }.toInt()
+                    courses.add(
+                        Course(
+                            name = courseName,
+                            day = getDayInt(day),
+                            room = place,
+                            teacher = teacher,
+                            startNode = startNode,
+                            endNode = endNode,
+                            startWeek = startWeek,
+                            endWeek = endWeek,
+                            type = 0,
+                            note = "开课对象：$courseObject"
+                        )
+                    )
                 }
-            }
             }
         }
         return courses

--- a/src/main/java/test/HUSTTest.kt
+++ b/src/main/java/test/HUSTTest.kt
@@ -4,7 +4,7 @@ import main.java.parser.HUSTParser
 import java.io.File
 
 fun main() {
-    val file = File("E:\\Temple\\hust.course.html")
+    val file = File("E:\\hust.course.html")
     val parser = HUSTParser(file.readText())
     parser.saveCourse()
 


### PR DESCRIPTION
WakeUp 当前使用的华中科技大学教务网站已于近期无法访问。

![image](https://github.com/user-attachments/assets/90efa63d-204e-482f-8861-2270e5a6a2e4)

新教务系统似乎无法获取上课人数信息，因此暂时删去。