### PR TITLE
支持 CSV 导出与完整课表解析（WISTParser）

### DIFF
--- a/src/main/java/parser/WISTParser.kt
+++ b/src/main/java/parser/WISTParser.kt
@@ -30,7 +30,6 @@ import parser.Parser
 class WISTParser(private val source: String) : Parser() {
 
     //生成课程列表的核心逻辑从 HTML 中提取课程信息，转换为标准 Course 列表，合并课表时间与周次信息
-
     override fun generateCourseList(): List<Course> {
         val courseList = ArrayList<Course>() // 原始课程列表
         val doc = Jsoup.parse(source) // 解析输入的HTML内容

--- a/src/main/java/parser/WISTParser.kt
+++ b/src/main/java/parser/WISTParser.kt
@@ -8,67 +8,92 @@ import org.jsoup.Jsoup
 import parser.Parser
 
 /**
- * WISTParser
- * @author Qing90bing
- * 学校：武汉船舶职业技术学院
- * 2025-04-24为止，该学校教务系统为金智教育系统
- * 因为是测试自己学院的，不知道其他学院的情况
+ * WISTParser 教务课表解析器
+ * 适配：武汉船舶职业技术学院 金智教务系统
+ * 日期：2025-05-21
+ * 作者：Qing90bing
+ * 注意：2025-05-21为止，该学校教务系统为金智教育系统
+ * 因为是测试自己学院的，不知道其他学院情况，有能力的话可以在issue中留言，把课表文件发给我
  * 查询流程：
  * 1.进入教务系统登录地址（统一身份验证）：http://authserver.wspc.edu.cn/authserver/login?service=http%3A%2F%2Fehall.wspc.edu.cn%2Flogin%3Fservice%3Dhttp%3A%2F%2Fehall.wspc.edu.cn%2Fnew%2Findex.html
  * 2.然后学生课表查询网址：http://jw.wspc.edu.cn/jwapp/sys/emaphome/portal/index.do
  * 3.进入课表会需要一段时间，请耐心等待，直到页面加载完成，然后最好点击打印，再获取课表，目前只是过这个步骤。
  *
- * 修改了解析课表代码，使其准确率更高
- **/
+ * 特性：
+ * ✅ 自动清洗周次字符串（支持"单周""双周""X-X周"等格式）
+ * ✅ 智能合并同一课程的不同周次记录
+ * ✅ 自动识别连续节次课程并合并（如3-4节连排合并为一个条目）
+ * ✅ 生成结构化课表数据（支持12节/天，20周学制）
+ * ✅ 包含详细的调试日志输出（可通过注释控制开关）
+ */
 
 class WISTParser(private val source: String) : Parser() {
 
+    //生成课程列表的核心逻辑从 HTML 中提取课程信息，转换为标准 Course 列表，合并课表时间与周次信息
+
     override fun generateCourseList(): List<Course> {
-        val courseList = mutableListOf<Course>()
-        val doc = Jsoup.parse(source)
+        val courseList = ArrayList<Course>() // 原始课程列表
+        val doc = Jsoup.parse(source) // 解析输入的HTML内容
+        val classNameSet = HashSet<String>() // 班级名称集合（自动去重）
 
-        // 遍历每个带课程的单元格
-        doc.select("td[data-role=item]").forEach { td ->
-            val day = td.attr("data-week").toIntOrNull() ?: return@forEach
+        // 获取每个单元格（td）作为一天中的课表格子
+        val itemCells = doc.select("td[data-role=item]")
+        for (td in itemCells) {
+            // 解析星期几（1-7对应周一到周日）
+            val day = td.attr("data-week").toIntOrNull() ?: continue
 
-            // 尝试从 td 属性读取节次范围
+            // 解析节次范围（数据属性或文本内容）
             val beginNodeAttr = td.attr("data-begin-unit").toIntOrNull()
             val endNodeAttr = td.attr("data-end-unit").toIntOrNull()
 
-            td.select("div.mtt_arrange_item").forEach { block ->
-                val name = block.selectFirst(".mtt_item_kcmc")?.ownText()?.trim() ?: return@forEach
+            // 提取单元格内的所有课程块
+            val courseDivs = td.select("div.mtt_arrange_item")
+            for (block in courseDivs) {
+                // 解析课程基础信息
+                val name = block.selectFirst(".mtt_item_kcmc")?.ownText()?.trim() ?: continue
                 val teacher = block.selectFirst(".mtt_item_jxbmc")?.text()?.trim().orEmpty()
                 val roomInfoRaw = block.selectFirst(".mtt_item_room")?.text()?.trim().orEmpty()
 
-                val rawParts = roomInfoRaw.split(",", "，").map(String::trim)
-
-                // 提取周数字段
-                val weekParts = rawParts.filter { it.contains("周") }
-                if (weekParts.isEmpty()) return@forEach
-                val rawWeekStr = weekParts.joinToString(",") { it.replace("周", "") }
-                val weekStr = rawWeekStr.replace(Regex("[^0-9\\-,]"), "")
-
-                // 节次提取：优先使用属性，失败才回退
-                val (beginNode, endNode) = if (beginNodeAttr != null && endNodeAttr != null) {
-                    Pair(beginNodeAttr, endNodeAttr)
-                } else {
-                    val nodePart = rawParts.firstOrNull {
-                        it.matches(Regex("^(中?[1-9]\\d?)(-(中?[1-9]\\d?))?$"))
-                    } ?: return@forEach
-                    val nodes = nodePart.split("-")
-                    Pair(parseNode(nodes.first()), parseNode(nodes.last()))
+                // 提取班级名（可用于课表命名）
+                block.selectFirst(".mtt_item_bjmc")?.text()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                    classNameSet += it
                 }
 
+                // 解析周次信息
+                val rawParts = roomInfoRaw.split(Regex("[,，]")).map(String::trim)
+                val weekParts = rawParts.filter { it.contains("周") }
+                if (weekParts.isEmpty()) continue
+
+                val fullWeekStr = weekParts.joinToString(",")
+                val isOdd = fullWeekStr.contains("单")
+                val isEven = fullWeekStr.contains("双")
+
+                // 仅保留数字部分，去除“周”等非数字干扰
+                val weekStrCleaned = weekParts.joinToString(",") {
+                    it.replace("周", "")
+                }.replace(" ", "")
+
+                // 提取节次范围（优先使用 data- 属性）
+                val (beginNode, endNode) = extractNodeRange(beginNodeAttr, endNodeAttr, rawParts)
+                if (beginNode <= 0 || endNode <= 0) continue
                 val step = endNode - beginNode + 1
+                val room = extractRoom(rawParts)
 
-                // 提取地点字段
-                val roomCandidates = rawParts.filter { !it.contains("周") && !Regex("^(中?[1-9]\\d?)(-(中?[1-9]\\d?))?$").matches(it) }
-                val room = roomCandidates.find {
-                    it.contains("实验室") || it.contains("教室") || it.contains("机房")
-                } ?: roomCandidates.firstOrNull().orEmpty()
+                // DEBUG: 以下为解析调试日志，在数据进入WISTTest.kt文件前，可用于排查解析失败或异常周次
+                // val parsedWeeks = parseWeeks(weekStrCleaned, isOdd, isEven)
+                // println("══════════════════════════════════════════════")
+                // println("📚 课程名称       : $name")
+                // println("🗓️ 上课星期       : 星期$day")
+                // println("⏰ 上课节次       : 第 $beginNode 节 ～ 第 $endNode 节")
+                // println("👨‍🏫 任课教师       : $teacher")
+                // println("🏫 原始周次字符串  : $fullWeekStr")
+                // println("🧼 清洗后周次     : $weekStrCleaned")
+                // println("🔢 单/双周判断    : 单周 = $isOdd ，双周 = $isEven")
+                // println("📅 解析结果周次   : $parsedWeeks")
+                // println("══════════════════════════════════════════════\n")
 
-                // 周次遍历生成课程
-                parseWeeks(weekStr).forEach { week ->
+                // 按每周生成一个 Course 对象（适配课表结构）
+                for (week in parseWeeks(weekStrCleaned, isOdd, isEven)) {
                     courseList += Course(
                         name = name,
                         teacher = teacher,
@@ -86,55 +111,37 @@ class WISTParser(private val source: String) : Parser() {
             }
         }
 
-        // 合并周课程
-        val merged = mutableListOf<Course>()
-        Common.mergeWeekCourse(courseList as ArrayList<Course>, merged as ArrayList<Course>)
+        // 合并周次相同、节次相同的课程
+        val merged = ArrayList<Course>()
+        Common.mergeWeekCourse(courseList, merged)
+
+        // 生成课程时间表（用于后续显示/提醒）
         Common.generateTimeTable(merged, generateTimeTable())
 
-        // 合并相邻节次课程
-        merged.sortWith(compareBy(
-            { it.name }, { it.teacher }, { it.room }, { it.day },
-            { it.startWeek }, { it.endWeek }, { it.startNode }
-        ))
-
-        val optimized = mutableListOf<Course>()
-        var i = 0
-        while (i < merged.size) {
-            var current = merged[i]
-            var j = i + 1
-            while (j < merged.size) {
-                val next = merged[j]
-                if (
-                    current.name == next.name &&
-                    current.teacher == next.teacher &&
-                    current.room == next.room &&
-                    current.day == next.day &&
-                    current.startWeek == next.startWeek &&
-                    current.endWeek == next.endWeek &&
-                    current.type == next.type &&
-                    current.endNode + 1 == next.startNode
-                ) {
-                    // 合并节次
-                    current = current.copy(
-                        endNode = next.endNode,
-                        step = next.endNode - current.startNode + 1
-                    )
-                    j++
-                } else {
-                    break
-                }
-            }
-            optimized.add(current)
-            i = j
-        }
-
+        // 合并相邻节次（上下节连排）
+        val optimized = mergeAdjacentNodes(merged)
+        this.classNames = classNameSet.toList().sorted()
         return optimized
     }
 
-    override fun getTableName(): String = "武船课表"
+    private var classNames: List<String> = emptyList()
+
+    //返回学校课表名称（包含班级信息）
+    override fun getTableName(): String {
+        return if (classNames.isNotEmpty()) {
+            "武船" + classNames.joinToString(",") + "课表"
+        } else {
+            "武船课表"
+        }
+    }
+
+    //获取每日最大节次（固定为12节）
     override fun getNodes(): Int = 12
+
+    //学校最大周数
     override fun getMaxWeek(): Int = 20
 
+    //定义标准时间表（武汉船舶职业技术学院专用）
     override fun generateTimeTable(): TimeTable = TimeTable(
         name = "武汉船舶职业技术学院",
         timeList = listOf(
@@ -152,48 +159,116 @@ class WISTParser(private val source: String) : Parser() {
             TimeDetail(12, "19:55", "20:40")
         )
     )
+    //解析周次字段（如 1-3,5-7(单),10-14(双)）
+    private fun parseWeeks(rawText: String, ignored1: Boolean = false, ignored2: Boolean = false): List<Int> {
+        val weekList = mutableSetOf<Int>()
+        val parts = rawText.split(",")
 
-    /**
-     * 解析周次字符串，支持：单周、范围、逗号分隔、混合
-     * 示例输入："2-6,8,10-13"
-     */
-    private fun parseWeeks(weekStr: String): List<Int> {
-        return weekStr
-            .split(",")
-            .map { it.trim() }
-            .filter { it.matches(Regex("^\\d+(?:-\\d+)?$")) }
-            .flatMap { part ->
-                part.split("-").let { range ->
-                    if (range.size == 1) {
-                        listOfNotNull(range[0].toIntOrNull())
-                    } else {
-                        val start = range[0].toIntOrNull() ?: return@flatMap emptyList()
-                        val end = range[1].toIntOrNull() ?: return@flatMap emptyList()
-                        (start..end).toList()
-                    }
-                }
+        for (part in parts) {
+            val isOdd = part.contains("单")
+            val isEven = part.contains("双")
+
+            // 清洗周次数字部分（如 12-14(双) -> 12-14）
+            val clean = part.replace(Regex("[^0-9\\-]"), "")
+            val weekRange = if ("-" in clean) {
+                val (start, end) = clean.split("-").mapNotNull { it.toIntOrNull() }
+                (start..end).toList()
+            } else {
+                listOfNotNull(clean.toIntOrNull())
             }
-            .toSortedSet()  // 去重并排序
-            .toList()
+
+            val filtered = when {
+                isOdd -> weekRange.filter { it % 2 == 1 }
+                isEven -> weekRange.filter { it % 2 == 0 }
+                else -> weekRange
+            }
+
+            weekList += filtered
+        }
+
+        return weekList.toList().sorted()
     }
 
-    /**
-     * 解析节次，支持“中1”->5、“中2”->6，以及数字
-     */
+    //判断某一周是否是有效的（单/双周筛选）
+    private fun isValidWeek(week: Int, isOdd: Boolean, isEven: Boolean): Boolean {
+        return if (isOdd) week % 2 == 1 else if (isEven) week % 2 == 0 else true
+    }
+
+    //解析节次字符串（支持“中1”、“中2”等中午节次）
     private fun parseNode(str: String): Int = when {
-        str.contains("中1") -> 5
-        str.contains("中2") -> 6
-        else -> str.filter { it.isDigit() }.toIntOrNull() ?: -1
+        str.contains("中1") -> 5  // 中午第1节对应第5节
+        str.contains("中2") -> 6  // 中午第2节对应第6节
+        else -> str.filter(Char::isDigit).toIntOrNull() ?: -1
     }
 
+    //提取开始和结束节次
+    private fun extractNodeRange(beginAttr: Int?, endAttr: Int?, parts: List<String>): Pair<Int, Int> {
+        return if (beginAttr != null && endAttr != null) {
+            Pair(beginAttr, endAttr)
+        } else {
+            val nodePart = parts.firstOrNull { nodePattern.matches(it) } ?: return Pair(-1, -1)
+            val nodes = nodePart.split("-")
+            Pair(parseNode(nodes.first()), parseNode(nodes.last()))
+        }
+    }
+
+    //提取教室信息
+    private fun extractRoom(parts: List<String>): String {
+        val roomRegex = Regex("实验室|教室|机房")
+        return parts.firstOrNull {
+            !it.contains("周") && !it.matches(Regex("^(中?[1-9]\\d?)(-(中?[1-9]\\d?))?$")) && roomRegex.containsMatchIn(it)
+        } ?: parts.firstOrNull {
+            !it.contains("周") && !it.matches(Regex("^(中?[1-9]\\d?)(-(中?[1-9]\\d?))?$"))
+        }.orEmpty()
+    }
+
+    //合并相邻节次的课程（如第1-2节与3-4节相邻且内容一致）
+    private fun mergeAdjacentNodes(courses: List<Course>): List<Course> {
+        val sorted = courses.sortedWith(
+            compareBy<Course> { it.name }
+                .thenBy { it.teacher }
+                .thenBy { it.room }
+                .thenBy { it.day }
+                .thenBy { it.startWeek }
+                .thenBy { it.endWeek }
+                .thenBy { it.startNode }
+        )
+        val result = ArrayList<Course>()
+        var current = sorted[0]
+
+        for (i in 1 until sorted.size) {
+            val next = sorted[i]
+            if (
+                current.name == next.name &&
+                current.teacher == next.teacher &&
+                current.room == next.room &&
+                current.day == next.day &&
+                current.startWeek == next.startWeek &&
+                current.endWeek == next.endWeek &&
+                current.type == next.type &&
+                current.endNode + 1 == next.startNode
+            ) {
+                current = current.copy(
+                    endNode = next.endNode,
+                    step = next.endNode - current.startNode + 1
+                )
+            } else {
+                result += current
+                current = next
+            }
+        }
+        result += current
+        return result
+    }
+
+    //从完整 HTML 中提取课表表格部分
     companion object {
-        /**
-         * 从完整 HTML 中提取出课表表格 HTML
-         */
+        private val weekPattern = Regex("[^0-9\\-,(单双)]")
+
+        private val nodePattern = Regex("^(中?[1-9]\\d?)(-(中?[1-9]\\d?))?$")
+
         fun extractTableHtml(fullHtml: String): String? {
-            val doc = Jsoup.parse(fullHtml)
-            val table = doc.selectFirst("table.wut_table") ?: return null
-            return table.outerHtml()
+            return Jsoup.parse(fullHtml).selectFirst("table.wut_table")?.outerHtml()
         }
     }
 }

--- a/src/main/java/test/WISTTest.kt
+++ b/src/main/java/test/WISTTest.kt
@@ -8,12 +8,11 @@ import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.system.measureTimeMillis
 
-
 fun main() {
     // ======================== [ ⚙️配置区 - 调试开关 ] ========================
     val enableCourseDetailLog  = true     // 是否打印每门课的详细信息
     val enableConflictCheck    = true     // 是否检查课程冲突
-    val enableWeekSummary      = false     // 是否汇总相同课程的所有周数
+    val enableWeekSummary      = true     // 是否汇总相同课程的所有周数
     val enableRoomSummary      = false     // 是否统计课程使用的所有教室
     val enableDurationSummary  = false     // 是否统计每门课总课时
     val enableTimeSummary      = true     // 是否统计解析课表的总时间
@@ -25,7 +24,7 @@ fun main() {
     // 示例中用了相对路径，Windows 下可能需要修改
     // 建议从项目外引用 html 文件
     // 提交时一定不要上传 html 文件，涉及隐私问题
-    val htmlFilePath = "D:/Download/Programs/WCtest2.html"
+    val htmlFilePath = "D:/Download/Programs/WC23845.html"
     val htmlContent = try {
         File(htmlFilePath).readText()
     } catch (e: IOException) {
@@ -51,7 +50,6 @@ fun main() {
         return
     }
 
-    // ======== 3. 打印课程详情（可配置） ========
     if (enableCourseDetailLog) {
         val groupedCourses = courseList.groupBy {
             listOf(it.name, it.teacher, it.room, it.day, it.startNode, it.endNode)
@@ -60,18 +58,33 @@ fun main() {
         println("\n📚 课程解析详情\n" + "-".repeat(50))
         groupedCourses.values.forEachIndexed { index, group ->
             val sample = group.first()
-            val weeks = group.map { it.startWeek }.sorted()
+
+            // 解析每个课程的周次
+            val weeks = group.flatMap { course ->
+                // 提取原始周次数据
+                val allWeeks = (course.startWeek..course.endWeek).toSet()
+
+                // 判断是否包含单周/双周标记
+                val weekType = course.type // 1为单周，0为不处理单双周
+
+                // 根据类型处理
+                val filteredWeeks = when (weekType) {
+                    1 -> allWeeks.filter { it % 2 == 1 }  // 单周，保留奇数周
+                    0 -> allWeeks // 不做单双周判断，直接保留所有周次
+                    else -> allWeeks.filter { it % 2 == 0 }  // 默认处理为双周，保留偶数周
+                }
+
+                filteredWeeks
+            }.toSet().sorted()
 
             // 说明课程为单周或双周（不强制，仅提示）
             val weekTypeDesc = when (sample.type) {
-                1 -> when {
-                    weeks.all { it % 2 == 1 } -> "（单周）"
-                    weeks.all { it % 2 == 0 } -> "（双周）"
-                    else -> ""
-                }
+                1 -> if (weeks.all { it % 2 == 1 }) "（单周）"
+                else if (weeks.all { it % 2 == 0 }) "（双周）" else ""
                 else -> ""
             }
 
+            // 打印课程详情
             println("🔹 第 ${index + 1} 门课".padEnd(30, '─'))
             println("📓 课程名称 : ${sample.name}")
             println("🧑🏻‍🏫 教师     : ${sample.teacher}")
@@ -89,16 +102,17 @@ fun main() {
     if (enableConflictCheck) {
         println("\n🔍 冲突检测结果\n" + "-".repeat(50))
         val conflicts = mutableListOf<Pair<Course, Course>>()
-        for (i in 0 until courseList.size - 1) {
-            val a = courseList[i]
+        for (i in courseList.indices) {
             for (j in i + 1 until courseList.size) {
+                val a = courseList[i]
                 val b = courseList[j]
-                if (
-                    a.startWeek == b.startWeek &&
-                    a.day == b.day &&
-                    a.startNode <= b.endNode &&
-                    b.startNode <= a.endNode
-                ) {
+
+                // 核心：比较是否为同一周、同一天、时间重叠
+                val sameWeek = a.startWeek == b.startWeek
+                val sameDay = a.day == b.day
+                val timeOverlap = a.startNode <= b.endNode && b.startNode <= a.endNode
+
+                if (sameWeek && sameDay && timeOverlap) {
                     conflicts += a to b
                 }
             }
@@ -126,8 +140,16 @@ fun main() {
 
         courseList.forEach { course ->
             val key = "${course.name}__${course.teacher}"
-            val weeks = (course.startWeek..course.endWeek).toSet()
+            val allWeeks = (course.startWeek..course.endWeek).toSet()
             val room = course.room.trim()
+
+            // 判断是否是单双周
+            val weekType = course.type // 1为单双周，0为不处理单双周
+            val weeks = when (weekType) {
+                1 -> allWeeks.filter { it % 2 == 1 }.toSet()  // 单周，保留奇数周
+                0 -> allWeeks // 不做单双周处理，保留所有周次
+                else -> allWeeks.filter { it % 2 == 0 }.toSet()  // 默认处理为双周，保留偶数周
+            }
 
             // 汇总上课周数
             if (enableWeekSummary) {
@@ -205,13 +227,7 @@ fun main() {
                         val sample = group.first()
 
                         // 确保周次列表只包含有效的整数
-                        val validWeekList = group.mapNotNull {
-                            try {
-                                it.startWeek
-                            } catch (e: NumberFormatException) {
-                                null // 过滤非整数值
-                            }
-                        }.sorted()
+                        val validWeekList = group.flatMap { it.startWeek..it.endWeek }.toSet().sorted()
 
                         // 生成格式化的周次字符串
                         val weekTypeDesc = when (sample.type) {

--- a/src/main/java/test/WISTTest.kt
+++ b/src/main/java/test/WISTTest.kt
@@ -3,60 +3,282 @@ package main.java.test
 import main.java.parser.WISTParser
 import bean.Course
 import java.io.File
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.system.measureTimeMillis
+
 
 fun main() {
-    // 1. 读取 HTML 文件内容（请替换为你自己的 HTML 文件路径）
+    // ======================== [ ⚙️配置区 - 调试开关 ] ========================
+    val enableCourseDetailLog  = true     // 是否打印每门课的详细信息
+    val enableConflictCheck    = true     // 是否检查课程冲突
+    val enableWeekSummary      = false     // 是否汇总相同课程的所有周数
+    val enableRoomSummary      = false     // 是否统计课程使用的所有教室
+    val enableDurationSummary  = false     // 是否统计每门课总课时
+    val enableTimeSummary      = true     // 是否统计解析课表的总时间
+    // ======================== [ ⚙️CSV配置区 - 调试开关 ] ========================
+    val enableCsvExport        = true     // 是否启用 CSV 导出功能
+    // =====================================================================
+
+    // ======== 1. 读取 HTML 文件内容 ========
     // 示例中用了相对路径，Windows 下可能需要修改
     // 建议从项目外引用 html 文件
     // 提交时一定不要上传 html 文件，涉及隐私问题
-    // 示例：D:/Download/Programs/WCtest.html
-    val htmlFilePath = "D:/Download/Programs/WCtest.html"
-    val htmlContent = File(htmlFilePath).readText()
-
-    // 2. 初始化解析器并获取课程列表
-    val parser = WISTParser(htmlContent)
-    val courseList: List<Course> = parser.generateCourseList()
-
-    // 3. 打印结果
-
-    courseList.forEachIndexed { index, course ->
-        println("第 ${index + 1} 门课：")
-        println("  📓课程名   : ${course.name}")
-        println("  🧑🏻‍🏫教师     : ${course.teacher}")
-        println("  🌤️周数     : ${course.startWeek} - ${course.endWeek} (type=${course.type})")
-        println("  🧵节次     : ${course.startNode} - ${course.endNode}")
-        println("  ⏲️时间     : ${course.startTime} - ${course.endTime}")
-        println("  📅星期     : ${course.day}")
-        println("  🧭地点     : ${course.room}")
-        println("  📝备注     : ${course.note}")
-        println()
+    val htmlFilePath = "D:/Download/Programs/WCtest2.html"
+    val htmlContent = try {
+        File(htmlFilePath).readText()
+    } catch (e: IOException) {
+        println("❌ 无法读取 HTML 文件: ${e.message}")
+        return
     }
-    println("✅共解析出 ${courseList.size} 门课程：")
-    println()
 
-    // 4. 检查并列出冲突课程
-    println("🔍 检查课程冲突：")
-    val conflicts = mutableListOf<Pair<Course, Course>>()
-    for (i in 0 until courseList.size) {
-        for (j in i + 1 until courseList.size) {
+    println("🕒 当前时间：${SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(Date())}")
+
+    // ======== 2. 初始化解析器并获取课程列表 ========
+    lateinit var courseList: List<Course>
+    val duration = measureTimeMillis {
+        try {
+            val parser = WISTParser(htmlContent)
+            courseList = parser.generateCourseList()
+        } catch (e: Exception) {
+            println("❌ 解析器异常：${e.message}")
+            return
+        }
+    }
+    if (courseList.isEmpty()) {
+        println("📭 未解析出任何课程，请检查 HTML 内容是否正确。")
+        return
+    }
+
+    // ======== 3. 打印课程详情（可配置） ========
+    if (enableCourseDetailLog) {
+        val groupedCourses = courseList.groupBy {
+            listOf(it.name, it.teacher, it.room, it.day, it.startNode, it.endNode)
+        }
+
+        println("\n📚 课程解析详情\n" + "-".repeat(50))
+        groupedCourses.values.forEachIndexed { index, group ->
+            val sample = group.first()
+            val weeks = group.map { it.startWeek }.sorted()
+
+            // 说明课程为单周或双周（不强制，仅提示）
+            val weekTypeDesc = when (sample.type) {
+                1 -> when {
+                    weeks.all { it % 2 == 1 } -> "（单周）"
+                    weeks.all { it % 2 == 0 } -> "（双周）"
+                    else -> ""
+                }
+                else -> ""
+            }
+
+            println("🔹 第 ${index + 1} 门课".padEnd(30, '─'))
+            println("📓 课程名称 : ${sample.name}")
+            println("🧑🏻‍🏫 教师     : ${sample.teacher}")
+            println("📅 周数     : ${weeks.joinToString(", ")} $weekTypeDesc")
+            println("⏰ 节次     : 第 ${sample.startNode} - ${sample.endNode} 节")
+            println("📆 星期     : 周 ${sample.day}")
+            println("📍 地点     : ${sample.room}")
+            println("📝 备注     : ${sample.note}")
+            println()
+        }
+        println("📥 共解析出 ${courseList.size} 门课程。")
+    }
+
+    // ======== 4. 冲突检测（可配置） ========
+    if (enableConflictCheck) {
+        println("\n🔍 冲突检测结果\n" + "-".repeat(50))
+        val conflicts = mutableListOf<Pair<Course, Course>>()
+        for (i in 0 until courseList.size - 1) {
             val a = courseList[i]
-            val b = courseList[j]
-            val sameDay = a.day == b.day
-            val weekOverlap = a.startWeek <= b.endWeek && b.startWeek <= a.endWeek
-            val timeOverlap = a.startNode <= b.endNode && b.startNode <= a.endNode
-            if (sameDay && weekOverlap && timeOverlap) {
-                conflicts += Pair(a, b)
+            for (j in i + 1 until courseList.size) {
+                val b = courseList[j]
+                if (
+                    a.startWeek == b.startWeek &&
+                    a.day == b.day &&
+                    a.startNode <= b.endNode &&
+                    b.startNode <= a.endNode
+                ) {
+                    conflicts += a to b
+                }
+            }
+        }
+
+        if (conflicts.isEmpty()) {
+            println("✅ 未发现课程冲突。😄")
+        } else {
+            println("⚠️ 共发现 ${conflicts.size} 处冲突😔：")
+            conflicts.forEachIndexed { idx, (c1, c2) ->
+                println("🆘 冲突 ${idx + 1}")
+                println("🅰️ ${c1.name} (周${c1.startWeek}-${c1.endWeek}, 周${c1.day}, 节${c1.startNode}-${c1.endNode})")
+                println("🅱️ ${c2.name} (周${c2.startWeek}-${c2.endWeek}, 周${c2.day}, 节${c2.startNode}-${c2.endNode})\n")
             }
         }
     }
-    if (conflicts.isEmpty()) {
-        println("✅ 未发现课程冲突。")
-    } else {
-        println("⚠️ 共发现 ${conflicts.size} 处课程冲突：")
-        conflicts.forEachIndexed { idx, (c1, c2) ->
-            println("  冲突 ${idx + 1}:")
-            println("  课程 A: ${c1.name} (星期${c1.day}, 周${c1.startWeek}-${c1.endWeek}, 节次 ${c1.startNode}-${c1.endNode})")
-            println("  课程 B: ${c2.name} (星期${c2.day}, 周${c2.startWeek}-${c2.endWeek}, 节次 ${c2.startNode}-${c2.endNode})")
+
+    // ======== 5. 汇总分析：周数、教室、总课时 ========
+    if (enableWeekSummary || enableRoomSummary || enableDurationSummary) {
+        println("\n📊 课程汇总分析\n" + "-".repeat(50))
+
+        val weekMap = mutableMapOf<String, MutableSet<Int>>()
+        val roomMap = mutableMapOf<String, MutableSet<String>>()
+        val hourMap = mutableMapOf<String, Int>()
+
+        courseList.forEach { course ->
+            val key = "${course.name}__${course.teacher}"
+            val weeks = (course.startWeek..course.endWeek).toSet()
+            val room = course.room.trim()
+
+            // 汇总上课周数
+            if (enableWeekSummary) {
+                weekMap.getOrPut(key) { mutableSetOf() }.addAll(weeks)
+            }
+
+            // 汇总教室信息
+            if (enableRoomSummary && room.isNotBlank()) {
+                roomMap.getOrPut(key) { mutableSetOf() }.add(room)
+            }
+
+            // 汇总课时数（按双节次为 1 节计）
+            if (enableDurationSummary) {
+                val duration = (course.endNode - course.startNode + 1) / 2
+                hourMap[key] = (hourMap[key] ?: 0) + duration * weeks.size
+            }
+        }
+
+        // 打印结果
+        weekMap.keys.union(roomMap.keys).union(hourMap.keys).forEach { key ->
+            val (name, teacher) = key.split("__")
+            println("📓 课程名 : $name")
+            println("🧑🏻‍🏫 教师   : $teacher")
+            if (enableWeekSummary) {
+                val weeks = weekMap[key]?.toList()?.sorted() ?: emptyList()
+                println("🌤️ 上课周 : $weeks")
+                println("🔢 周数段 : ${compactWeekList(weeks)}")
+            }
+            if (enableRoomSummary) {
+                val rooms = roomMap[key]?.toList()?.sorted() ?: emptyList()
+                println("🏫 教室列表 : ${rooms.joinToString("、")}")
+            }
+            if (enableDurationSummary) {
+                val totalHours = hourMap[key] ?: 0
+                println("⏱️ 总课时 : $totalHours 节")
+            }
+            println()
+        }
+
+        if (enableDurationSummary) {
+            println("🧮 所有课程合计上课节数：${hourMap.values.sum()} 节")
+            println("📌 注：每 2 个节次 node 计为 1 节课（如 node=1,2 为 1 节）\n")
         }
     }
+
+    if (enableTimeSummary) {
+        println("⏳ 本次课表汇总解析耗时：${duration}ms\n")
+    }
+    //  CSV导出功能
+    if (enableCsvExport) {
+        print("📤 是否导出课程表为 CSV 到桌面？（Y/n）：")
+        val answer = readLine()?.trim()?.lowercase()
+        if (answer.isNullOrEmpty() || answer == "y") {
+            try {
+                val desktopPath = System.getProperty("user.home") + "/Desktop"
+                val resultFolder = File(desktopPath, "解析结果")
+                if (!resultFolder.exists()) {
+                    resultFolder.mkdirs()
+                }
+
+                // 使用大写HH表示24小时制
+                val date = SimpleDateFormat("yyyyMMdd_HHmmss").format(Date())
+                val fileName = "课表导出_$date.csv"
+                val csvFile = File(resultFolder, fileName)
+
+                // 分组并整理为每组一行，包含所有周数
+                val grouped = courseList.groupBy {
+                    listOf(it.name, it.teacher, it.room, it.day, it.startNode, it.endNode)
+                }
+
+                csvFile.printWriter().use { writer ->
+                    writer.println("课程名称,星期,开始节数,结束节数,老师,地点,周数")
+
+                    for ((_, group) in grouped) {
+                        val sample = group.first()
+
+                        // 确保周次列表只包含有效的整数
+                        val validWeekList = group.mapNotNull {
+                            try {
+                                it.startWeek
+                            } catch (e: NumberFormatException) {
+                                null // 过滤非整数值
+                            }
+                        }.sorted()
+
+                        // 生成格式化的周次字符串
+                        val weekTypeDesc = when (sample.type) {
+                            1 -> when {
+                                validWeekList.all { it % 2 == 1 } -> "（单周）"
+                                validWeekList.all { it % 2 == 0 } -> "（双周）"
+                                else -> ""
+                            }
+                            else -> ""
+                        }
+                        val weekStr = "${compactWeekList(validWeekList)} $weekTypeDesc".trim()
+
+                        // 关键修复：用双引号包裹可能包含逗号的字段
+                        val line = listOf(
+                            escapeCsvField(sample.name),
+                            sample.day.toString(),
+                            sample.startNode.toString(),
+                            sample.endNode.toString(),
+                            escapeCsvField(sample.teacher),
+                            escapeCsvField(sample.room),
+                            escapeCsvField(weekStr)
+                        ).joinToString(",")
+
+                        writer.println(line)
+                    }
+                }
+
+                println("✅ CSV 导出成功！文件位置：${csvFile.absolutePath}")
+            } catch (e: Exception) {
+                println("❌ 导出失败：${e.message}")
+            }
+        } else {
+            println("📁 用户选择取消导出。")
+        }
+    }
+    println("🏁 测试结束:)\n" + "-".repeat(50))
+}
+
+/**
+ * 工具函数：
+ * 将整数周列表如 [1,2,3,5,6,9] 转换为格式化段落字符串 "1-3,5-6,9"
+ * 用于更美观地上课周数展示
+ */
+fun compactWeekList(weeks: List<Int>): String {
+    if (weeks.isEmpty()) return ""
+    val result = mutableListOf<String>()
+    var start = weeks[0]
+    var end = weeks[0]
+
+    for (i in 1 until weeks.size) {
+        if (weeks[i] == end + 1) {
+            end = weeks[i]
+        } else {
+            result += if (start == end) "$start" else "$start-$end"
+            start = weeks[i]
+            end = weeks[i]
+        }
+    }
+    result += if (start == end) "$start" else "$start-$end"
+    return result.joinToString(",")
+}
+
+// 新增：CSV字段转义函数，处理特殊字符
+fun escapeCsvField(field: String): String {
+    // 如果字段包含逗号、引号或换行符，则用双引号包裹并转义内部引号
+    if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
+        return "\"${field.replace("\"", "\"\"")}\""
+    }
+    return field
 }


### PR DESCRIPTION
✨ 功能概述
本次提交主要新增和完善了以下功能：
完善 WISTParser 课表解析器
支持从金智教务系统中解析课程信息。
支持完整节次、周次、教室、备注字段提取。
自动识别单周/双周、节次范围，保留原始周数字符串。
增强测试器功能（test/Main.kt）
✅ 添加调试开关（是否打印详情、是否导出、是否检测冲突等）。
✅ 自动统计解析耗时。
✅ 课程冲突检测，支持节次重叠检查。
✅ 输出清晰的课程详情与结构化信息。
CSV 导出功能
默认导出为 解析结果/xxx.csv，保存在桌面。
导出结构示例：
所有字段均为 纯文本，不会自动转化为日期或数字，适合办公软件直接打开。
若桌面目录不存在会自动创建。