### PR TITLE
fix: 北京航空航天大学

### DIFF
--- a/src/main/java/bean/BUAACourseInfo.kt
+++ b/src/main/java/bean/BUAACourseInfo.kt
@@ -1,10 +1,27 @@
 package main.java.bean
 
+/**
+ * GSON 数据类，用于映射北航教务系统课表 API 的 JSON 响应。
+ * 顶层结构。
+ *
+ * @property code 状态码，通常成功时为 0。
+ * @property msg 响应信息。
+ * @property datas 核心数据负载。
+ */
 data class BUAACourseInfo(
     val code: Int,
     val msg: String,
     val datas: Datas
 ) {
+    /**
+     * 包含所有课表列表的核心数据模型。
+     *
+     * @property arrangedList 已安排（有具体时间地点）的课程列表。
+     * @property notArrangeList 未安排的课程列表。
+     * @property practiceList 实践类课程列表。
+     * @property code 未知用途的编码。
+     * @property name 未知用途的名称。
+     */
     data class Datas(
         val arrangedList: List<CourseItem>,
         val notArrangeList: List<CourseItem>,
@@ -12,6 +29,31 @@ data class BUAACourseInfo(
         val code: String,
         val name: String
     ) {
+        /**
+         * 代表一个具体的课程项目信息。
+         *
+         * @property week 星期（例如："星期一"），但通常使用 dayOfWeek。
+         * @property courseCode 课程代码。
+         * @property credit 学分。
+         * @property courseName 课程名称。
+         * @property byCode 未知用途编码。
+         * @property beginSection 开始节次。
+         * @property endSection 结束节次。
+         * @property titleDetail 标题详情列表，包含课程的各种详细信息。
+         * @property multiCourse 是否为多课程。
+         * @property teachClassName 教学班名称。
+         * @property placeName 上课地点。
+         * @property teachingTarget 教学对象。
+         * @property weeksAndTeachers 包含周次和教师的聚合字符串。
+         * @property teachClassId 教学班ID。
+         * @property cellDetail UI单元格的详细信息，通常包含教师和周次。
+         * @property tags 课程标签。
+         * @property courseSerialNo 课程序号。
+         * @property startTime 课程开始时间 (格式 "HH:mm")。
+         * @property endTime 课程结束时间 (格式 "HH:mm")。
+         * @property color 用于UI显示的颜色代码。
+         * @property dayOfWeek 星期几，一个整数 (例如，1代表周一)。
+         */
         data class CourseItem(
             val week: String = "",
             val courseCode: String = "",
@@ -20,21 +62,27 @@ data class BUAACourseInfo(
             val byCode: String = "",
             val beginSection: Int = 0,
             val endSection: Int = 0,
-            val titleDetail: List<String> = listOf(),
+            val titleDetail: List<String> = emptyList(),
             val multiCourse: String = "",
             val teachClassName: String = "",
             val placeName: String = "",
             val teachingTarget: String = "",
             val weeksAndTeachers: String = "",
             val teachClassId: String = "",
-            val cellDetail: List<CellDetail> = listOf(),
-            val tags: List<String> = listOf(),
+            val cellDetail: List<CellDetail> = emptyList(),
+            val tags: List<String> = emptyList(),
             val courseSerialNo: String = "",
-            val beginTime: String = "",
+            val startTime: String = "",
             val endTime: String = "",
             val color: String = "",
             val dayOfWeek: Int = 0
         ) {
+            /**
+             * 课表UI单元格的显示细节。
+             *
+             * @property color 文本颜色。
+             * @property text 显示的文本内容。
+             */
             data class CellDetail(
                 val color: String = "",
                 val text: String = ""

--- a/src/main/java/parser/BUAAParser.kt
+++ b/src/main/java/parser/BUAAParser.kt
@@ -8,24 +8,44 @@ import main.java.bean.TimeTable
 import parser.Parser
 
 /**
- * Date: 2024/03/02
- * 课表地址: https://byxt.buaa.edu.cn/ -> 查询 -> 课表查询 -> 我的课表
- * 项目地址: https://github.com/PandZz/CourseAdapter
- * 作者: PandZz
+ * 北京航空航天大学本研教务系统课表解析器。
  *
- * 北京航空航天大学-新本研教务
- * 解析了POST(https://byxt.buaa.edu.cn/jwapp/sys/homeapp/api/home/student/getMyScheduleDetail.do)的返回结果(json)
+ * 该解析器用于处理从北航新版教务系统 API 获取的课表 JSON 数据。
+ * API 端点: `https://byxt.buaa.edu.cn/jwapp/sys/homeapp/api/home/student/getMyScheduleDetail.do` (POST)
+ *
+ * @param source 从 API 获取的原始 JSON 字符串。
+ * @author PandZz
+ * @date 2024/03/02
  */
-
 class BUAAParser(source: String) : Parser(source) {
-    private val teacherAndWeekRegex = Regex("""^(.+)\[(\d+)-(\d+)周(?:\(([单双])\))?]$""")
-    override fun getNodes(): Int {
-        return 14
+
+    /**
+     * 定义了课程表中一天最大的课程节数。
+     * 北航课表通常为14节。
+     * @return 课程节数。
+     */
+    override fun getNodes(): Int = 14
+
+    /**
+     * 从源 JSON 数据中解析并生成课程列表。
+     * @return [Course] 对象的列表，每个对象代表一节具体的课程安排。
+     */
+    override fun generateCourseList(): List<Course> {
+        val response = Gson().fromJson(source, BUAACourseInfo::class.java)
+        // 将每个 CourseItem 转换为一个或多个 Course 对象，并最终合并成一个列表
+        return response.datas.arrangedList.flatMap { courseItem ->
+            parseCourseItem(courseItem)
+        }
     }
 
+    /**
+     * 生成北京航空航天大学的时间表。
+     * @return [TimeTable] 对象，包含所有课程节次的起止时间。
+     */
     override fun generateTimeTable(): TimeTable {
         return TimeTable(
-            name = "北京航空航天大学", timeList = listOf(
+            name = "北京航空航天大学",
+            timeList = listOf(
                 TimeDetail(1, "08:00", "08:45"),
                 TimeDetail(2, "08:50", "09:35"),
                 TimeDetail(3, "09:50", "10:35"),
@@ -46,73 +66,93 @@ class BUAAParser(source: String) : Parser(source) {
         )
     }
 
-    override fun generateCourseList(): List<Course> {
-        val result = arrayListOf<Course>()
-        val response = Gson().fromJson(source, BUAACourseInfo::class.java)
-        response.datas.arrangedList.forEach { courseItem ->
-            parseCourseItem(courseItem).forEach {
-                result.add(it)
-            }
-        }
-        return result
-    }
-
-    data class TeacherAndWeek(
+    /**
+     * 内部数据类，用于临时存储从字符串中解析出的教师和周次信息。
+     *
+     * @property teacher 教师姓名。
+     * @property startWeek 开始周。
+     * @property endWeek 结束周。
+     * @property type 周次类型 (0: 每周, 1: 单周, 2: 双周)。
+     */
+    private data class TeacherAndWeek(
         val teacher: String,
-        val beginWeek: Int,
+        val startWeek: Int,
         val endWeek: Int,
-        val type: Int // 0: 每周, 1: 单周, 2: 双周
-    )
-
-    // 解析教师和周数, 例如: "张三[1-16周(单)]" -> TeacherAndWeek("张三", 1, 16, 1)
-    private fun parseTeacherAndWeek(teachersAndWeeks: String): TeacherAndWeek {
-        val matchResult = teacherAndWeekRegex.find(teachersAndWeeks)
-        if (matchResult != null) {
-            val (teacher, beginWeekStr, endWeekStr, typeStr) = matchResult.destructured
-            val beginWeek = beginWeekStr.toInt()
-            val endWeek = endWeekStr.toInt()
-            val type = when (typeStr) {
-                "单" -> 1
-                "双" -> 2
-                else -> 0
-            }
-
-            val teacherAndWeek = TeacherAndWeek(teacher, beginWeek, endWeek, type)
-//            println(teacherAndWeek)
-            return teacherAndWeek
+        val type: Int
+    ) {
+        companion object {
+            const val TYPE_ALL = 0  // 每周
+            const val TYPE_ODD = 1  // 单周
+            const val TYPE_EVEN = 2 // 双周
         }
-        return TeacherAndWeek("", 0, 0, 0)
     }
 
+    /**
+     * 解析单个课程项目，将其转换为一个或多个 [Course] 对象。
+     *
+     * 一个 CourseItem 可能因为有多个老师或不同的上课周次（例如，"李四[1-8周] 王五[9-16周]"）
+     * 而需要被解析成多个 Course 对象。
+     *
+     * @param courseItem 从 JSON 解析出的原始课程项。
+     * @return 解析后的 [Course] 对象列表。
+     */
     private fun parseCourseItem(courseItem: BUAACourseInfo.Datas.CourseItem): List<Course> {
-        val result = arrayListOf<Course>()
-        val cellDetail = courseItem.cellDetail
-        val name = courseItem.courseName
-        val day = courseItem.dayOfWeek
-        val room = courseItem.placeName
-        cellDetail[1].text.split(" ").forEach { teacherAndWeeks ->
-            val teacherAndWeek = parseTeacherAndWeek(teacherAndWeeks)
-            val teacher = teacherAndWeek.teacher
-            val beginWeek = teacherAndWeek.beginWeek
-            val endWeek = teacherAndWeek.endWeek
-            val type = teacherAndWeek.type
-            val course = Course(
-                name = name,
-                day = day,
-                room = room,
-                teacher = teacher,
-                startNode = courseItem.beginSection,
-                endNode = courseItem.endSection,
-                startWeek = beginWeek,
-                endWeek = endWeek,
-                type = type,
-                credit = courseItem.credit.toFloat(),
-                note = courseItem.titleDetail[8],
-                startTime = courseItem.beginTime,
-                endTime = courseItem.endTime
-            )
-            result.add(course)
+        // "cellDetail[1].text" 字段通常包含教师和周次信息，格式如 "张三[1-16周(单)] 李四[1-16周(双)]"
+        return courseItem.cellDetail[1].text.split(" ").mapNotNull { teacherAndWeeksString ->
+            parseTeacherAndWeek(teacherAndWeeksString)?.let { teacherAndWeek ->
+                Course(
+                    name = courseItem.courseName,
+                    day = courseItem.dayOfWeek,
+                    room = courseItem.placeName,
+                    teacher = teacherAndWeek.teacher,
+                    startNode = courseItem.beginSection,
+                    endNode = courseItem.endSection,
+                    startWeek = teacherAndWeek.startWeek,
+                    endWeek = teacherAndWeek.endWeek,
+                    type = teacherAndWeek.type,
+                    credit = courseItem.credit.toFloatOrNull() ?: 0f,
+                    note = courseItem.titleDetail.getOrElse(8) { "" },
+                    startTime = courseItem.startTime,
+                    endTime = courseItem.endTime
+                )
+            }
         }
-        return result
+    }
+
+    /**
+     * 解析包含教师姓名、起止周和周次类型的字符串。
+     *
+     * 例如: "张三[1-16周(单)]" -> TeacherAndWeek("张三", 1, 16, 1)
+     *
+     * @param input 待解析的字符串。
+     * @return 如果解析成功，返回 [TeacherAndWeek] 对象；否则返回 `null`。
+     */
+    private fun parseTeacherAndWeek(input: String): TeacherAndWeek? {
+        return teacherAndWeekRegex.find(input)?.let { matchResult ->
+            val (teacher, beginWeekStr, endWeekStr, typeStr) = matchResult.destructured
+            val type = when (typeStr) {
+                "单" -> TeacherAndWeek.TYPE_ODD
+                "双" -> TeacherAndWeek.TYPE_EVEN
+                else -> TeacherAndWeek.TYPE_ALL
+            }
+            TeacherAndWeek(
+                teacher = teacher,
+                startWeek = beginWeekStr.toInt(),
+                endWeek = endWeekStr.toInt(),
+                type = type
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * 用于从字符串中提取教师姓名、开始周、结束周和单双周类型的正则表达式。
+         * - Group 1: (.+) -> 教师姓名
+         * - Group 2: (\d+) -> 开始周
+         * - Group 3: (\d+) -> 结束周
+         * - Group 4: ([单双]) -> 单双周标识 (可选)
+         */
+        private const val TEACHER_AND_WEEK_REGEX_PATTERN = """^(.+)\[(\d+)-(\d+)周(?:\(([单双])\))?]$"""
+        private val teacherAndWeekRegex = Regex(TEACHER_AND_WEEK_REGEX_PATTERN)
     }
 }

--- a/src/main/java/parser/BUAAParser.kt
+++ b/src/main/java/parser/BUAAParser.kt
@@ -11,6 +11,10 @@ import parser.Parser
  * 北京航空航天大学本研教务系统课表解析器。
  *
  * 该解析器用于处理从北航新版教务系统 API 获取的课表 JSON 数据。
+ * 使用方法：访问 https://byxt.buaa.edu.cn/ ，登录后依次点击
+ *          “查询” -> “课表查询” -> “我的课表” -> “学期课表”
+ *          然后点击界面右下角下载按钮导入课表。
+ * 注意：一定要记得切换到学期课表，否则可能漏课。
  * API 端点: `https://byxt.buaa.edu.cn/jwapp/sys/homeapp/api/home/student/getMyScheduleDetail.do` (POST)
  *
  * ---

--- a/src/main/java/parser/BUAAParser.kt
+++ b/src/main/java/parser/BUAAParser.kt
@@ -13,9 +13,18 @@ import parser.Parser
  * 该解析器用于处理从北航新版教务系统 API 获取的课表 JSON 数据。
  * API 端点: `https://byxt.buaa.edu.cn/jwapp/sys/homeapp/api/home/student/getMyScheduleDetail.do` (POST)
  *
+ * ---
+ * ### 变更历史
+ * - **v2.0.0 (2025-09-07 by oNya):**
+ *   - 重构解析核心，将数据源从 `cellDetail` 迁移至 `titleDetail` 中的 "上课教师" 字段，以适应新版数据格式。
+ *   - 实现了对复杂、非连续周次字符串（如 "[1-3周,5周(单)]"）的解析。
+ *   - 增强了对多教师共同授课情况的处理能力。
+ *
  * @param source 从 API 获取的原始 JSON 字符串。
- * @author PandZz
+ * @author PandZz (初版)
+ * @author oNya (v2.0.0)
  * @date 2024/03/02
+ * @version 2.0.0
  */
 class BUAAParser(source: String) : Parser(source) {
 
@@ -67,51 +76,55 @@ class BUAAParser(source: String) : Parser(source) {
     }
 
     /**
-     * 内部数据类，用于临时存储从字符串中解析出的教师和周次信息。
+     * 内部数据类，用于临时存储从字符串中解析出的周次信息。
      *
-     * @property teacher 教师姓名。
      * @property startWeek 开始周。
      * @property endWeek 结束周。
      * @property type 周次类型 (0: 每周, 1: 单周, 2: 双周)。
      */
-    private data class TeacherAndWeek(
-        val teacher: String,
-        val startWeek: Int,
-        val endWeek: Int,
-        val type: Int
-    ) {
-        companion object {
-            const val TYPE_ALL = 0  // 每周
-            const val TYPE_ODD = 1  // 单周
-            const val TYPE_EVEN = 2 // 双周
-        }
-    }
+    private data class WeekInfo(val startWeek: Int, val endWeek: Int, val type: Int)
 
     /**
      * 解析单个课程项目，将其转换为一个或多个 [Course] 对象。
      *
-     * 一个 CourseItem 可能因为有多个老师或不同的上课周次（例如，"李四[1-8周] 王五[9-16周]"）
-     * 而需要被解析成多个 Course 对象。
+     * 新逻辑从 `titleDetail` 中查找 "上课教师：" 字段，并解析其后复杂的教师和周次安排字符串。
+     * 例如："上课教师：张三/[6-17周]/6-7节 李四/[1-3周,5周,6-10周(双)]/6-7节"
      *
      * @param courseItem 从 JSON 解析出的原始课程项。
      * @return 解析后的 [Course] 对象列表。
      */
     private fun parseCourseItem(courseItem: BUAACourseInfo.Datas.CourseItem): List<Course> {
-        // "cellDetail[1].text" 字段通常包含教师和周次信息，格式如 "张三[1-16周(单)] 李四[1-16周(双)]"
-        return courseItem.cellDetail[1].text.split(" ").mapNotNull { teacherAndWeeksString ->
-            parseTeacherAndWeek(teacherAndWeeksString)?.let { teacherAndWeek ->
+        // 1. 从 titleDetail 找到包含教师信息的字符串
+        val teacherInfoSource = courseItem.titleDetail
+            .find { it.startsWith("上课教师：") }
+            ?.substringAfter("上课教师：")
+            ?: return emptyList() // 如果找不到信息，则返回空列表
+
+        // 2. 按空格分割，处理多个教师或时间段的情况
+        return teacherInfoSource.split(" ").flatMap { teacherBlock ->
+            val parts = teacherBlock.split('/')
+            if (parts.size < 2) return@flatMap emptyList<Course>()
+
+            val teacherName = parts[0]
+            val weeksString = parts[1]
+
+            // 3. 解析周次字符串，这可能会产生多个 WeekInfo 对象
+            val weekInfos = parseWeeksString(weeksString)
+
+            // 4. 为每个解析出的周次信息创建一个 Course 对象
+            weekInfos.map { weekInfo ->
                 Course(
                     name = courseItem.courseName,
                     day = courseItem.dayOfWeek,
                     room = courseItem.placeName,
-                    teacher = teacherAndWeek.teacher,
+                    teacher = teacherName,
                     startNode = courseItem.beginSection,
                     endNode = courseItem.endSection,
-                    startWeek = teacherAndWeek.startWeek,
-                    endWeek = teacherAndWeek.endWeek,
-                    type = teacherAndWeek.type,
+                    startWeek = weekInfo.startWeek,
+                    endWeek = weekInfo.endWeek,
+                    type = weekInfo.type,
                     credit = courseItem.credit.toFloatOrNull() ?: 0f,
-                    note = courseItem.titleDetail.getOrElse(8) { "" },
+                    note = courseItem.titleDetail.getOrElse(8) { "" }, // 安全地获取备注
                     startTime = courseItem.startTime,
                     endTime = courseItem.endTime
                 )
@@ -120,39 +133,52 @@ class BUAAParser(source: String) : Parser(source) {
     }
 
     /**
-     * 解析包含教师姓名、起止周和周次类型的字符串。
+     * 解析包含复杂周次信息的字符串。
      *
-     * 例如: "张三[1-16周(单)]" -> TeacherAndWeek("张三", 1, 16, 1)
-     *
-     * @param input 待解析的字符串。
-     * @return 如果解析成功，返回 [TeacherAndWeek] 对象；否则返回 `null`。
+     * @param weeksString 格式如 "[1-3周(单),7-13周(单)]" 或 "[1-3周,5周]" 的字符串。
+     * @return 一个包含所有解析出的周次规则的 [WeekInfo] 列表。
      */
-    private fun parseTeacherAndWeek(input: String): TeacherAndWeek? {
-        return teacherAndWeekRegex.find(input)?.let { matchResult ->
-            val (teacher, beginWeekStr, endWeekStr, typeStr) = matchResult.destructured
+    private fun parseWeeksString(weeksString: String): List<WeekInfo> {
+        return weeksString.removeSurrounding("[", "]").split(',').mapNotNull { pattern ->
+            parseWeekPattern(pattern.trim())
+        }
+    }
+
+    /**
+     * 解析单个周次模式字符串。
+     *
+     * @param pattern 格式如 "1-3周(单)", "7-13周", 或 "5周" 的字符串。
+     * @return 解析成功则返回 [WeekInfo] 对象，否则返回 `null`。
+     */
+    private fun parseWeekPattern(pattern: String): WeekInfo? {
+        return weekPatternRegex.find(pattern)?.let { matchResult ->
+            // 使用解构声明获取正则捕获组
+            val (startWeekStr, endWeekStr, typeStr) = matchResult.destructured
+            val startWeek = startWeekStr.toInt()
+            // 如果 endWeekStr 为空（例如 "5周"），则结束周等于开始周
+            val endWeek = endWeekStr.ifEmpty { startWeekStr }.toInt()
             val type = when (typeStr) {
-                "单" -> TeacherAndWeek.TYPE_ODD
-                "双" -> TeacherAndWeek.TYPE_EVEN
-                else -> TeacherAndWeek.TYPE_ALL
+                "单" -> TYPE_ODD
+                "双" -> TYPE_EVEN
+                else -> TYPE_ALL
             }
-            TeacherAndWeek(
-                teacher = teacher,
-                startWeek = beginWeekStr.toInt(),
-                endWeek = endWeekStr.toInt(),
-                type = type
-            )
+            WeekInfo(startWeek, endWeek, type)
         }
     }
 
     companion object {
+        private const val TYPE_ALL = 0  // 每周
+        private const val TYPE_ODD = 1  // 单周
+        private const val TYPE_EVEN = 2 // 双周
+
         /**
-         * 用于从字符串中提取教师姓名、开始周、结束周和单双周类型的正则表达式。
-         * - Group 1: (.+) -> 教师姓名
-         * - Group 2: (\d+) -> 开始周
-         * - Group 3: (\d+) -> 结束周
-         * - Group 4: ([单双]) -> 单双周标识 (可选)
+         * 用于解析单个周次模式的正则表达式。
+         * - Group 1: (\d+)         -> 开始周 (例如 "1" 或 "5")
+         * - Group 2: (?:-(\d+))?   -> 结束周 (可选, 例如 "3")
+         * - Group 3: (?:\(([单双])\))? -> 周类型 (可选, 例如 "单")
+         *
+         * 示例匹配: "1-3周(单)", "7-13周", "5周"
          */
-        private const val TEACHER_AND_WEEK_REGEX_PATTERN = """^(.+)\[(\d+)-(\d+)周(?:\(([单双])\))?]$"""
-        private val teacherAndWeekRegex = Regex(TEACHER_AND_WEEK_REGEX_PATTERN)
+        private val weekPatternRegex = Regex("""(\d+)(?:-(\d+))?周(?:\(([单双])\))?""")
     }
 }

--- a/src/main/java/test/BUAATest.kt
+++ b/src/main/java/test/BUAATest.kt
@@ -4,7 +4,7 @@ import main.java.parser.BUAAParser
 import java.io.File
 
 fun main() {
-    val source = File("C:/Users/R7000P/OneDrive/桌面/getMyScheduleDetail.do.json")
+    val source = File("getMyScheduleDetail.do.json")
         .readText()
     BUAAParser(source).apply {
         generateCourseList()


### PR DESCRIPTION
- 新增对例如 `[1-3周(单),7-13周(单)]` 或 `[1-3周,5周]` 的老师多周次排课的解析。
- 优化代码结构，提高可维护性。